### PR TITLE
sc-review-2020012701: This removes the note library from the open() call

### DIFF
--- a/src/OasisCdpManager.sol
+++ b/src/OasisCdpManager.sol
@@ -39,10 +39,8 @@ contract OasisCdpManager is LibNote {
 
     // Open a new cdp for msg.sender address.
     function open(
-        bytes32 ilk,
-        address usr
+        bytes32 ilk
     ) public returns (address urn) {
-        require(usr != address(0), "usr-address-0");
         require(urns[msg.sender][ilk] == address(0), "cannot-override-urn");
         urn = address(new UrnHandler(vat));
         urns[msg.sender][ilk] = urn;

--- a/src/OasisCdpManager.sol
+++ b/src/OasisCdpManager.sol
@@ -41,15 +41,13 @@ contract OasisCdpManager is LibNote {
     function open(
         bytes32 ilk,
         address usr
-    ) public note returns (address urn) {
+    ) public returns (address urn) {
         require(usr != address(0), "usr-address-0");
         require(urns[usr][ilk] == address(0), "cannot-override-urn");
 
         urn = address(new UrnHandler(vat));
         urns[usr][ilk] = urn;
 
-        // TODO: Decide if the note is enough.  If not, we should remove note
-        // and keep NewCdp().  Whatever we do, there is no need to log both.
         emit NewCdp(usr, ilk, urn);
     }
 


### PR DESCRIPTION
The idea here is that we don't need both the note library and the event.  In other locations in the code when we make this call, we typically keep the custom event and drop the `note`.  Discuss.