### PR TITLE
Add open() if urn has not been created and test

### DIFF
--- a/src/OasisCdpManager.sol
+++ b/src/OasisCdpManager.sol
@@ -115,8 +115,8 @@ contract OasisCdpManager is LibNote {
     function enter(
         bytes32 ilk
     ) public note {
-        address urn = urns[msg.sender][ilk];
-        require(urn != address(0), "not-existing-urn");
+        address urn = (urns[msg.sender][ilk] != address(0)) ? urns[msg.sender][ilk] : open(ilk);
+
         (uint ink, uint art) = VatLike(vat).urns(ilk, msg.sender);
         VatLike(vat).fork(
             ilk,

--- a/src/OasisCdpManager.t.sol
+++ b/src/OasisCdpManager.t.sol
@@ -142,4 +142,32 @@ contract OasisCdpManagerTest is DssDeployTestBase {
         assertEq(art, 0);
     }
 
+    function testEnterWithNewUrn() public {
+        weth.deposit.value(1 ether)();
+        weth.approve(address(ethJoin), 1 ether);
+        ethJoin.join(address(this), 1 ether);
+        vat.frob("ETH", address(this), address(this), address(this), 1 ether, 50 ether);
+
+        (uint ink, uint art) = vat.urns("ETH", manager.urns(address(this), "ETH"));
+        assertEq(manager.urns(address(this), "ETH"), address(0));
+        assertEq(ink, 0);
+        assertEq(art, 0);
+
+        (ink, art) = vat.urns("ETH", address(this));
+        assertEq(ink, 1 ether);
+        assertEq(art, 50 ether);
+
+        vat.hope(address(manager));
+        manager.enter("ETH");
+        if (manager.urns(address(this), "ETH") == address(0)) { fail(); }
+
+        (ink, art) = vat.urns("ETH", manager.urns(address(this), "ETH"));
+        assertEq(ink, 1 ether);
+        assertEq(art, 50 ether);
+
+        (ink, art) = vat.urns("ETH", address(this));
+        assertEq(ink, 0);
+        assertEq(art, 0);
+    }
+
 }


### PR DESCRIPTION
Adds a fallback to open() an urn on enter if one does not exist.
Also adds a test of the new functionality.