### PR TITLE
sc-review-2020012901: adds custom OasisCdpManagerEvents

### DIFF
--- a/src/OasisCdpManager.sol
+++ b/src/OasisCdpManager.sol
@@ -17,47 +17,47 @@ contract UrnHandler {
 
 contract OasisCdpManagerEvents {
     event OpenEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn
+        address usr,
+        bytes32 ilk,
+        address indexed urn
     );
 
     event FrobEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn,
+        address usr,
+        bytes32 ilk,
+        address indexed urn,
         int dink,
         int dart
     );
 
     event FluxEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn,
+        address usr,
+        bytes32 ilk,
+        address indexed urn,
         address dst,
         uint wad
     );
 
     event MoveEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn,
+        address usr,
+        bytes32 ilk,
+        address indexed urn,
         address dst,
         uint rad
     );
 
     event QuitEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn,
+        address usr,
+        bytes32 ilk,
+        address indexed urn,
         int dink,
         int dart
     );
 
     event EnterEvent(
-        address indexed usr,
-        bytes32 indexed ilk,
-        address urn,
+        address usr,
+        bytes32 ilk,
+        address indexed urn,
         int dink,
         int dart
     );

--- a/src/OasisCdpManager.sol
+++ b/src/OasisCdpManager.sol
@@ -17,13 +17,13 @@ contract UrnHandler {
 
 contract OasisCdpManagerEvents {
     event OpenEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn
     );
 
     event FrobEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn,
         int dink,
@@ -31,7 +31,7 @@ contract OasisCdpManagerEvents {
     );
 
     event FluxEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn,
         address dst,
@@ -39,7 +39,7 @@ contract OasisCdpManagerEvents {
     );
 
     event MoveEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn,
         address dst,
@@ -47,7 +47,7 @@ contract OasisCdpManagerEvents {
     );
 
     event QuitEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn,
         int dink,
@@ -55,7 +55,7 @@ contract OasisCdpManagerEvents {
     );
 
     event EnterEvent(
-        address usr,
+        address indexed usr,
         bytes32 ilk,
         address indexed urn,
         int dink,


### PR DESCRIPTION
this PR:

- updates the solidity pragma
- removes `LibNote`
- removes an unused library now
- creates a set of events under `OasisCdpManagerEvents`.  We need to think about those indexes.
- changes the event name of `NewCdp` to `OpenEvent`
- fires a specific event for each function in `OasisCdpManager`
- only adds an index on urn as `msg.sender` and `ilk` are extremely low cardinality and thus poor index choices